### PR TITLE
Missing ScryptParams bug

### DIFF
--- a/examples/create_public_key.py
+++ b/examples/create_public_key.py
@@ -1,5 +1,5 @@
 import getpass
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 
 ################################################
 
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     password = getpass.getpass("Enter your password: ")
 
     # Create key object
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # Display your public key
     print("Public key for your credentials: %s" % key.pubkey)


### PR DESCRIPTION
  File "create_public_key.py", line 15, in <module>
    key = SigningKey(salt, password)
TypeError: __init__() missing 1 required positional argument: 'scrypt_params'