### PR TITLE
Add ScryptParams to examples files to avoid SigningKey call error

### DIFF
--- a/examples/create_and_publish_identity.py
+++ b/examples/create_and_publish_identity.py
@@ -12,7 +12,7 @@ from duniterpy.key import SigningKey, ScryptParams
 # You can either use a complete defined endpoint : [NAME_OF_THE_API] [DOMAIN] [IPv4] [IPv6] [PORT]
 # or the simple definition : [NAME_OF_THE_API] [DOMAIN] [PORT]
 # Here we use the BASIC_MERKLED_API
-BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.madeinzion.org 10900"
+BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.duniter.org 10900"
 
 # Your unique identifier in the Web of Trust
 UID = "LibreBankSMS"

--- a/examples/create_and_publish_identity.py
+++ b/examples/create_and_publish_identity.py
@@ -4,7 +4,7 @@ import getpass
 
 import duniterpy.api.bma as bma
 from duniterpy.documents import BMAEndpoint, BlockUID, Identity
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 
 
 # CONFIG #######################################
@@ -12,10 +12,10 @@ from duniterpy.key import SigningKey
 # You can either use a complete defined endpoint : [NAME_OF_THE_API] [DOMAIN] [IPv4] [IPv6] [PORT]
 # or the simple definition : [NAME_OF_THE_API] [DOMAIN] [PORT]
 # Here we use the BASIC_MERKLED_API
-BMA_ENDPOINT = "BASIC_MERKLED_API g1.duniter.org 10901"
+BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.madeinzion.org 10900"
 
 # Your unique identifier in the Web of Trust
-UID = "MyIdentity"
+UID = "LibreBankSMS"
 
 ################################################
 # Latest duniter-python-api is asynchronous and you have to create an aiohttp session to send request
@@ -39,7 +39,7 @@ def get_identity_document(current_block, uid, salt, password):
     timestamp = BlockUID(current_block['number'], current_block['hash'])
 
     # create keys from credentials
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # create identity document
     identity = Identity(

--- a/examples/create_public_key.py
+++ b/examples/create_public_key.py
@@ -1,5 +1,5 @@
 import getpass
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 
 ################################################
 
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     password = getpass.getpass("Enter your password: ")
 
     # Create key object
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # Display your public key
     print("Public key for your credentials: %s" % key.pubkey)

--- a/examples/save_private_keys.py
+++ b/examples/save_private_keys.py
@@ -1,4 +1,4 @@
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 import getpass
 import os
 
@@ -30,7 +30,7 @@ password = getpass.getpass("Enter your password: ")
 pubkey = input("Enter your public key: ")
 
 # init signer instance
-signer = SigningKey(salt, password)\
+signer = SigningKey(salt, password, ScryptParams(4096, 16, 1))\
 
 # check public key
 if signer.pubkey != pubkey:

--- a/examples/save_revoke_document.py
+++ b/examples/save_revoke_document.py
@@ -3,7 +3,7 @@ import aiohttp
 import duniterpy.api.bma as bma
 from duniterpy.documents import BMAEndpoint, BlockUID, Identity
 from duniterpy.documents import Revocation
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 import getpass
 import os
 
@@ -86,7 +86,7 @@ def get_revoke_document(identity, salt, password):
     """
     document = Revocation(PROTOCOL_VERSION, identity.currency, identity.pubkey, "")
 
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
     document.sign(identity, [key])
     return document.signed_raw(identity)
 
@@ -104,7 +104,7 @@ async def main():
     pubkey = input("Enter your public key: ")
 
     # init signer instance
-    signer = SigningKey(salt, password)
+    signer = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # check public key
     if signer.pubkey != pubkey:

--- a/examples/save_revoke_document.py
+++ b/examples/save_revoke_document.py
@@ -21,7 +21,7 @@ else:
 # You can either use a complete defined endpoint : [NAME_OF_THE_API] [DOMAIN] [IPv4] [IPv6] [PORT]
 # or the simple definition : [NAME_OF_THE_API] [DOMAIN] [PORT]
 # Here we use the BASIC_MERKLED_API
-BMA_ENDPOINT = "BASIC_MERKLED_API g1.duniter.org 10901"
+BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.duniter.org 10900"
 
 # WARNING : Hide this file in a safe and secure place
 # If one day you forget your credentials,

--- a/examples/send_certification.py
+++ b/examples/send_certification.py
@@ -3,7 +3,7 @@ import aiohttp
 import getpass
 import duniterpy.api.bma as bma
 from duniterpy.documents import BMAEndpoint, BlockUID, Identity, Certification
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 
 
 # CONFIG #######################################
@@ -80,7 +80,7 @@ def get_certification_document(current_block, self_cert_document, from_pubkey, s
         signature=""
     )
     # sign document
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
     certification.sign(self_cert_document, [key])
 
     return certification

--- a/examples/send_certification.py
+++ b/examples/send_certification.py
@@ -11,7 +11,7 @@ from duniterpy.key import SigningKey, ScryptParams
 # You can either use a complete defined endpoint : [NAME_OF_THE_API] [DOMAIN] [IPv4] [IPv6] [PORT]
 # or the simple definition : [NAME_OF_THE_API] [DOMAIN] [PORT]
 # Here we use the BASIC_MERKLED_API
-BMA_ENDPOINT = "BASIC_MERKLED_API g1.duniter.org 10901"
+BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.duniter.org 10900"
 
 ################################################
 

--- a/examples/send_membership.py
+++ b/examples/send_membership.py
@@ -4,7 +4,7 @@ import getpass
 
 import duniterpy.api.bma as bma
 from duniterpy.documents import BMAEndpoint, BlockUID, Identity, Membership
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 
 
 # CONFIG #######################################
@@ -37,7 +37,7 @@ def get_identity_document(current_block, uid, salt, password):
     timestamp = BlockUID(current_block['number'], current_block['hash'])
 
     # create keys from credentials
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # create identity document
     identity = Identity(
@@ -72,7 +72,7 @@ def get_membership_document(mtype, current_block, identity, salt, password):
     timestamp = BlockUID(current_block['number'], current_block['hash'])
 
     # create keys from credentials
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # create identity document
     membership = Membership(

--- a/examples/send_membership.py
+++ b/examples/send_membership.py
@@ -12,7 +12,7 @@ from duniterpy.key import SigningKey, ScryptParams
 # You can either use a complete defined endpoint : [NAME_OF_THE_API] [DOMAIN] [IPv4] [IPv6] [PORT]
 # or the simple definition : [NAME_OF_THE_API] [DOMAIN] [PORT]
 # Here we use the BASIC_MERKLED_API
-BMA_ENDPOINT = "BASIC_MERKLED_API g1.duniter.org 10901"
+BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.duniter.org 10900"
 
 ################################################
 

--- a/examples/send_transaction.py
+++ b/examples/send_transaction.py
@@ -6,7 +6,7 @@ from duniterpy.api import bma
 from duniterpy.documents import BMAEndpoint, BlockUID, Transaction
 from duniterpy.documents.transaction import InputSource, OutputSource, Unlock, SIGParameter
 from duniterpy.grammars.output import Condition, SIG
-from duniterpy.key import SigningKey
+from duniterpy.key import SigningKey, ScryptParams
 
 # CONFIG #######################################
 
@@ -125,7 +125,7 @@ async def main():
     transaction = get_transaction_document(current_block, source, pubkey_from, pubkey_to)
 
     # create keys from credentials
-    key = SigningKey(salt, password)
+    key = SigningKey(salt, password, ScryptParams(4096, 16, 1))
 
     # sign document
     transaction.sign([key])

--- a/examples/send_transaction.py
+++ b/examples/send_transaction.py
@@ -13,7 +13,7 @@ from duniterpy.key import SigningKey, ScryptParams
 # You can either use a complete defined endpoint : [NAME_OF_THE_API] [DOMAIN] [IPv4] [IPv6] [PORT]
 # or the simple definition : [NAME_OF_THE_API] [DOMAIN] [PORT]
 # Here we use the BASIC_MERKLED_API
-BMA_ENDPOINT = "BASIC_MERKLED_API g1.duniter.org 10901"
+BMA_ENDPOINT = "BASIC_MERKLED_API g1-test.duniter.org 10900"
 
 
 ################################################


### PR DESCRIPTION
    key = SigningKey(salt, password, **ScryptParams(4096, 16, 1)**)